### PR TITLE
re-enable execlists

### DIFF
--- a/bsw/files/grub
+++ b/bsw/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.enable_cmd_parser=0 i915.preliminary_hw_support=1 i915.enable_execlists=0"
+GRUB_CMDLINE_LINUX="i915.enable_cmd_parser=0 i915.preliminary_hw_support=1"


### PR DESCRIPTION
Disabling execlists had no affect on piglit failures, and it generated
hundreds of vulkan failures related to SSBO.
