### PR TITLE
enable cmd_parser

### DIFF
--- a/bdw/files/grub
+++ b/bdw/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.enable_cmd_parser=0 i915.preliminary_hw_support=1"
+GRUB_CMDLINE_LINUX="i915.preliminary_hw_support=1"

--- a/bsw/files/grub
+++ b/bsw/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.enable_cmd_parser=0 i915.preliminary_hw_support=1"
+GRUB_CMDLINE_LINUX="i915.preliminary_hw_support=1"

--- a/ivbgt1/files/grub
+++ b/ivbgt1/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.enable_cmd_parser=0"
+GRUB_CMDLINE_LINUX=""

--- a/slave/files/grub
+++ b/slave/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.enable_cmd_parser=0"
+GRUB_CMDLINE_LINUX=""

--- a/snb/files/grub
+++ b/snb/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.enable_cmd_parser=0 i915.semaphores=0 i915.enable_execlists=0"
+GRUB_CMDLINE_LINUX="i915.semaphores=0 i915.enable_execlists=0"


### PR DESCRIPTION
When the CI was first enabled, the command parser was problematic.
enable_cmd_parser=0 was specified by default on all platforms, but this
is no longer necessary.
