### PR TITLE
Remove grub options

### DIFF
--- a/bdw/files/grub
+++ b/bdw/files/grub
@@ -1,5 +1,0 @@
-GRUB_DEFAULT=0
-GRUB_TIMEOUT=5
-GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.preliminary_hw_support=1"

--- a/bdw/grub.sls
+++ b/bdw/grub.sls
@@ -1,7 +1,0 @@
-include:
-    - slave.grub
-
-extend:
-    /etc/default/grub:
-        file:
-            - source: salt://bdw/files/grub

--- a/bdw/init.sls
+++ b/bdw/init.sls
@@ -1,2 +1,0 @@
-include:
-    - bdw.grub

--- a/bsw/files/grub
+++ b/bsw/files/grub
@@ -1,5 +1,0 @@
-GRUB_DEFAULT=0
-GRUB_TIMEOUT=5
-GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.preliminary_hw_support=1"

--- a/bsw/grub.sls
+++ b/bsw/grub.sls
@@ -1,7 +1,0 @@
-include:
-    - slave.grub
-
-extend:
-    /etc/default/grub:
-        file:
-            - source: salt://bsw/files/grub

--- a/bsw/init.sls
+++ b/bsw/init.sls
@@ -1,2 +1,0 @@
-include:
-    - bsw.grub

--- a/hsw/files/grub
+++ b/hsw/files/grub
@@ -1,5 +1,0 @@
-GRUB_DEFAULT=0
-GRUB_TIMEOUT=5
-GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX=""

--- a/hsw/grub.sls
+++ b/hsw/grub.sls
@@ -1,7 +1,0 @@
-include:
-    - slave.grub
-
-extend:
-    /etc/default/grub:
-        file:
-            - source: salt://hsw/files/grub

--- a/hsw/init.sls
+++ b/hsw/init.sls
@@ -1,2 +1,0 @@
-include:
-    - hsw.grub

--- a/ivbgt1/files/grub
+++ b/ivbgt1/files/grub
@@ -1,5 +1,0 @@
-GRUB_DEFAULT=0
-GRUB_TIMEOUT=5
-GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX=""

--- a/ivbgt1/grub.sls
+++ b/ivbgt1/grub.sls
@@ -1,7 +1,0 @@
-include:
-    - slave.grub
-
-extend:
-    /etc/default/grub:
-        file:
-            - source: salt://ivbgt1/files/grub

--- a/ivbgt1/init.sls
+++ b/ivbgt1/init.sls
@@ -1,2 +1,0 @@
-include:
-    - ivbgt1.grub

--- a/kbl/files/grub
+++ b/kbl/files/grub
@@ -1,5 +1,0 @@
-GRUB_DEFAULT=0
-GRUB_TIMEOUT=5
-GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.preliminary_hw_support=1"

--- a/kbl/grub.sls
+++ b/kbl/grub.sls
@@ -1,7 +1,0 @@
-include:
-    - slave.grub
-
-extend:
-    /etc/default/grub:
-        file:
-            - source: salt://kbl/files/grub

--- a/kbl/init.sls
+++ b/kbl/init.sls
@@ -1,2 +1,0 @@
-include:
-    - kbl.grub

--- a/skl/files/grub
+++ b/skl/files/grub
@@ -1,5 +1,0 @@
-GRUB_DEFAULT=0
-GRUB_TIMEOUT=5
-GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.preliminary_hw_support=1"

--- a/skl/grub.sls
+++ b/skl/grub.sls
@@ -1,7 +1,0 @@
-include:
-    - slave.grub
-
-extend:
-    /etc/default/grub:
-        file:
-            - source: salt://skl/files/grub

--- a/skl/init.sls
+++ b/skl/init.sls
@@ -1,2 +1,0 @@
-include:
-    - skl.grub

--- a/slave/files/grub
+++ b/slave/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX=""
+GRUB_CMDLINE_LINUX="i915.preliminary_hw_support=1"

--- a/snb/files/grub
+++ b/snb/files/grub
@@ -2,4 +2,4 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=5
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="i915.semaphores=0 i915.enable_execlists=0"
+GRUB_CMDLINE_LINUX="i915.semaphores=0"

--- a/top.sls
+++ b/top.sls
@@ -5,10 +5,6 @@ base:
         - bsw
     '*bdw*':
         - bdw
-    '*hsw*':
-        - hsw
-    '*ivbgt1*':
-        - ivbgt1
     '*snb*':
         - snb
     '*skl*':

--- a/top.sls
+++ b/top.sls
@@ -1,15 +1,7 @@
 base:
     'otc-gfxtest-*':
         - slave
-    '*bsw*':
-        - bsw
-    '*bdw*':
-        - bdw
     '*snb*':
         - snb
-    '*skl*':
-        - skl
-    '*kbl*':
-        - kbl
 
 # vim: ft=yaml


### PR DESCRIPTION
After your last merge I was looking at the individual files, and noticed that we have a bunch of overrides for no reason. This mostly deletes a bunch of code and simplifies things considerably.

This will probably trigger a reboot of all of the systems when we apply it.
