### PR TITLE
Do not install i386 of libcrypt20-dev

### DIFF
--- a/slave/packages.sls
+++ b/slave/packages.sls
@@ -72,7 +72,7 @@ slave-packages:
             - libglu1-mesa-dev
             - libglu1-mesa:i386
             - libgcrypt20-dev
-            - libgcrypt20-dev:i386
+            - libgcrypt20:i386
             - libicu-dev:i386
             - libllvm3.7
             - libllvm3.7:i386


### PR DESCRIPTION
This package conflicts with the amd64 dev package.
